### PR TITLE
#131 pass event analytics to view

### DIFF
--- a/konfera/event/views.py
+++ b/konfera/event/views.py
@@ -9,6 +9,7 @@ from django.utils.translation import ugettext_lazy as _
 from konfera.event.forms import SpeakerForm, TalkForm
 from konfera.models.event import Event
 from konfera.models.talk import APPROVED, CFP
+from konfera.utils import set_event_ga_to_context
 
 
 def event_sponsors_list_view(request, event_slug):
@@ -60,6 +61,8 @@ def event_details_view(request, event_slug):
     event = get_object_or_404(Event.objects.published(), slug=event_slug)
     context['event'] = event
     context['sponsors'] = event.sponsors.all()
+
+    set_event_ga_to_context(event, context)
 
     return render(request=request, template_name='konfera/event_details.html', context=context)
 

--- a/konfera/event/views.py
+++ b/konfera/event/views.py
@@ -19,6 +19,8 @@ def event_sponsors_list_view(request, event_slug):
     context['event'] = event
     context['sponsors'] = event.sponsors.all().order_by('type', 'title')
 
+    set_event_ga_to_context(event, context)
+
     return render(request=request, template_name='konfera/event_sponsors.html', context=context)
 
 
@@ -28,6 +30,8 @@ def event_speakers_list_view(request, event_slug):
     event = get_object_or_404(Event.objects.published(), slug=event_slug)
     context['event'] = event
     context['talks'] = event.talk_set.filter(status=APPROVED).order_by('primary_speaker__last_name')
+
+    set_event_ga_to_context(event, context)
 
     return render(request=request, template_name='konfera/event_speakers.html', context=context)
 
@@ -88,6 +92,8 @@ def cfp_form_view(request, event_slug):
     context['speaker_form'] = speaker_form
     context['talk_form'] = talk_form
 
+    set_event_ga_to_context(event, context)
+
     return render(request=request, template_name='konfera/cfp_form.html', context=context)
 
 
@@ -113,5 +119,7 @@ class ScheduleView(DetailView):
             {'day': day, 'date': event.date_from + timedelta(days=day)}
             for day in range(event_duration.days + 1)
         ]
+
+        set_event_ga_to_context(event, context)
 
         return context

--- a/konfera/utils.py
+++ b/konfera/utils.py
@@ -11,3 +11,8 @@ def collect_view_data(request):
         view_data['ga'] = settings.GOOGLE_ANALYTICS
 
     return view_data
+
+
+def set_event_ga_to_context(event, context):
+    if event.analytics:
+        context['ga'] = event.analytics


### PR DESCRIPTION
- added a function in utils.py which can set event's analytics code to the context
- at this point, this function is called just when event's detail page is rendered.