### PR TITLE
Validation logic when saving a Ticket

### DIFF
--- a/konfera/tests/test_models.py
+++ b/konfera/tests/test_models.py
@@ -178,6 +178,27 @@ class TalkTest(TestCase):
 
 
 class TicketTest(TestCase):
+    def setUp(self):
+        time = timezone.now()
+        location = models.Location(title='test_title', street='test_street', city='test_city', postcode='000000',
+                                   state='test_state', capacity=20)
+        location.save()
+        event = models.Event(title='test_event', description='test', event_type='meetup',
+                             status=models.event.PUBLISHED, location=location, date_from=time, date_to=time)
+        event.save()
+        self.ticket_type = models.TicketType(title='test', description='test', price=100, event=event,
+                                             date_from=time, date_to=time)
+        self.ticket_type.save()
+        self.ticket_type_2 = models.TicketType(title='secondType', description='otherType', price=7, event=event,
+                                               date_from=time, date_to=time)
+        self.ticket_type_2.save()
+        self.discount_code = models.DiscountCode(title='test discount', hash='test', discount=60,
+                                                 date_from=time, date_to=time, usage=1,
+                                                 ticket_type=self.ticket_type)
+        self.discount_code.save()
+        self.discount_code_2 = models.DiscountCode(title='discount_2', hash='otherCode', discount=4,
+                                                   date_from=time, date_to=time, usage=100,
+                                                   ticket_type=self.ticket_type_2)
 
     def test_string_representation(self):
         """
@@ -193,26 +214,34 @@ class TicketTest(TestCase):
         )
 
     def test_automatic_order_generator(self):
-        time = timezone.now()
-        location = models.Location(title='test_title', street='test_street', city='test_city', postcode=000000,
-                                   state='test_state', capacity=20)
-        location.save()
-        event = models.Event(title='test_event', description='test', event_type='meetup',
-                             status=models.event.PUBLISHED, location=location, date_from=time, date_to=time)
-        event.save()
-        ticket_type = models.TicketType(title='test', description='test', price=100, event=event,
-                                        date_from=timezone.now(), date_to=timezone.now())
-        ticket_type.save()
-        discount_code = models.DiscountCode(title='test discount', hash='test', discount=60,
-                                            date_from=time, date_to=time, usage=1,
-                                            ticket_type=ticket_type)
-        discount_code.save()
-        ticket = models.Ticket(status='requested', title='mr', first_name="test", last_name="Test", type=ticket_type,
-                               email='test@test.com', phone='0912345678', discount_code=discount_code)
+
+        ticket = models.Ticket(status='requested', title='mr', first_name="test", last_name="Test",
+                               type=self.ticket_type, email='test@test.com', phone='0912345678',
+                               discount_code=self.discount_code)
         ticket.save()
         self.assertEquals(ticket.order.status, 'awaiting_payment')
-        self.assertEquals(ticket.order.price, ticket_type.price)
+        self.assertEquals(ticket.order.price, self.ticket_type.price)
         self.assertEquals(ticket.order.discount, 60)
+
+    def test_clean_and_save_ticket_discount_code(self):
+
+        # if saved with no discount_code, the ticket should save successfully
+        ticket_no_code = models.Ticket(status='requested', title='mr', first_name="test", last_name="Test",
+                                       type=self.ticket_type, email='test@test.com', phone='0912345678')
+        ticket_no_code.save()
+
+        # if saved with a code that matches the ticket type of the ticket, the ticket should save successfully
+        ticket_with_valid_code = models.Ticket(status='requested', title='mr', first_name="test", last_name="Test",
+                                               type=self.ticket_type, email='test@test.com', phone='0912345678',
+                                               discount_code=self.discount_code)
+        ticket_with_valid_code.save()
+
+        # if saved with a code that does not match the ticket type of the ticket, the ticket should
+        # raise a validationError
+        ticket_with_invalid_code = models.Ticket(status='requested', title='mr', first_name="test", last_name="Test",
+                                                 type=self.ticket_type, email='test@test.com', phone='0912345678',
+                                                 discount_code=self.discount_code_2)
+        self.assertRaises(ValidationError, ticket_with_invalid_code.save)
 
 
 class TicketTypeTest(TestCase):


### PR DESCRIPTION
fixes #148.
This pull request adds validation logic when saving a ticket, either by submitting a form or by saving manually, to ensure that the selected discount_code for the ticket is applicable to the ticket_type of the ticket being created.

I added a test in test_models.py to confirm that the logic works as intended.

Let me know if there are any questions!