### PR TITLE
#187 added landing page settings and handle redirecting on /index

### DIFF
--- a/konfera/settings.py
+++ b/konfera/settings.py
@@ -11,5 +11,9 @@ TALK_DURATION = getattr(settings, 'TALK_DURATION',
                             (45, _('45 min')),
                         ))
 
-# LANDING PAGE should be something like latest_conference or earliest_meetup or similar combinations
+"""LANDING PAGE is a composite of two keywords: <timewise>_<event>
+<timewise> can be: latest or earliest
+<event> can be (at the moment): conference or meetup
+possible combinations: latest_conference (DEFAULT), latest_meetup, earliest_conference, earliest_meetup
+"""
 LANDING_PAGE = getattr(settings, 'LANDING_PAGE', 'latest_conference')

--- a/konfera/settings.py
+++ b/konfera/settings.py
@@ -10,3 +10,6 @@ TALK_DURATION = getattr(settings, 'TALK_DURATION',
                             (30, _('30 min')),
                             (45, _('45 min')),
                         ))
+
+# LANDING PAGE should be something like latest_conference or earliest_meetup or similar combinations
+LANDING_PAGE = getattr(settings, 'LANDING_PAGE', 'latest_conference')

--- a/konfera/tests/test_views.py
+++ b/konfera/tests/test_views.py
@@ -169,15 +169,15 @@ class TestIndexRedirect(TestCase):
         )
 
     def test_no_conference(self):
+        response = self.client.get('')
+        # Check if status is OK and correct template is used
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'konfera/list_events.html')
+
         self.old_meetup = Event.objects.create(
-            title='Old meetup', slug='old-meetup', description='Old meetup', event_type='meetup',
+            title='Old meetup', slug='old-meetup', description='Old meetup', event_type=Event.MEETUP,
             status='published', location=self.location,
             date_from='2016-01-01 01:01:01+01:00', date_to='2016-01-01 01:01:01+01:00',
-        )
-        self.new_meetup = Event.objects.create(
-            title='New meetup', slug='new-meetup', description='New meetup', event_type='meetup',
-            status='published', location=self.location,
-            date_from='2017-01-01 01:01:01+01:00', date_to='2017-01-01 01:01:01+01:00',
         )
         response = self.client.get('')
         # Check if status is OK and correct template is used
@@ -186,7 +186,7 @@ class TestIndexRedirect(TestCase):
 
     def test_one_conference(self):
         self.old_conference = Event.objects.create(
-            title='Old conference', slug='old-conference', description='Old conference', event_type='conference',
+            title='Old conference', slug='old-conference', description='Old conference', event_type=Event.CONFERENCE,
             status='published', location=self.location,
             date_from='2016-01-01 01:01:01+01:00', date_to='2016-01-03 01:01:01+01:00',
         )
@@ -197,7 +197,7 @@ class TestIndexRedirect(TestCase):
 
     def test_latest_conference(self):
         self.new_conference = Event.objects.create(
-            title='New conference', slug='new-conference', description='New conference', event_type='conference',
+            title='New conference', slug='new-conference', description='New conference', event_type=Event.CONFERENCE,
             status='published', location=self.location,
             date_from='2017-01-01 01:01:01+01:00', date_to='2017-01-03 01:01:01+01:00',
         )

--- a/konfera/views.py
+++ b/konfera/views.py
@@ -1,8 +1,7 @@
-from django.shortcuts import redirect
-from django.views.generic import ListView
-from django.shortcuts import render
 from django.contrib import messages
-from django.utils.translation import ugettext_lazy as _
+from django.shortcuts import redirect
+from django.shortcuts import render
+from django.views.generic import ListView
 
 from konfera.models.event import Event
 from konfera.settings import LANDING_PAGE
@@ -14,12 +13,12 @@ def index(request):
         timewise = timewise.lower()
         event_type = event_type.upper()
     except BaseException as be:
-        raise (_('%s\nIncorrect LANDING_PAGE setting, need latest|earliest_conference|meetup', be))
+        raise ('%s\nIncorrect LANDING_PAGE setting, need latest|earliest_conference|meetup', be)
 
     events = Event.objects.published().filter(event_type=getattr(Event, event_type))
-    selected_event = getattr(events, timewise)('date_from')
+    selected_event = getattr(events, timewise)('date_from') if events else None
     if not selected_event:
-        messages.info(request, _('No %s event has been found. Redirected to default list.' % event_type))
+        messages.info(request, 'No %s event has been found. Redirected to default list.' % event_type)
         return render(request=request, template_name='konfera/list_events.html')
 
     return redirect('event_details', slug=selected_event.slug)

--- a/konfera/views.py
+++ b/konfera/views.py
@@ -1,6 +1,7 @@
 from django.contrib import messages
 from django.shortcuts import redirect
 from django.shortcuts import render
+from django.utils.translation import ugettext_lazy as _
 from django.views.generic import ListView
 
 from konfera.models.event import Event
@@ -18,7 +19,7 @@ def index(request):
     events = Event.objects.published().filter(event_type=getattr(Event, event_type))
     selected_event = getattr(events, timewise)('date_from') if events else None
     if not selected_event:
-        messages.info(request, 'No %s event has been found. Redirected to default list.' % event_type)
+        messages.info(request, _('No %s event has been found. Redirected to default list.' % event_type))
         return render(request=request, template_name='konfera/list_events.html')
 
     return redirect('event_details', slug=selected_event.slug)

--- a/konfera/views.py
+++ b/konfera/views.py
@@ -1,12 +1,28 @@
 from django.shortcuts import redirect
 from django.views.generic import ListView
+from django.shortcuts import render
+from django.contrib import messages
+from django.utils.translation import ugettext_lazy as _
 
 from konfera.models.event import Event
+from konfera.settings import LANDING_PAGE
 
 
 def index(request):
-    latest_conference = Event.objects.published().filter(event_type=Event.CONFERENCE).latest('date_from')
-    return redirect('event_details', slug=latest_conference.slug)
+    try:
+        timewise, event_type = LANDING_PAGE.split('_')
+        timewise = timewise.lower()
+        event_type = event_type.upper()
+    except BaseException as be:
+        raise (_('%s\nIncorrect LANDING_PAGE setting, need latest|earliest_conference|meetup', be))
+
+    events = Event.objects.published().filter(event_type=getattr(Event, event_type))
+    selected_event = getattr(events, timewise)('date_from')
+    if not selected_event:
+        messages.info(request, _('No %s event has been found. Redirected to default list.' % event_type))
+        return render(request=request, template_name='konfera/list_events.html')
+
+    return redirect('event_details', slug=selected_event.slug)
 
 
 class EventsByTypeListView(ListView):


### PR DESCRIPTION
We can discuss a way to handle LANDING_PAGE  - either hardcode all possibiities, or define rules to determine them dynamically. Current code suggests using default event latest or earliest, in case none is found, redirect to (empty) list of events of the same type. 
Tests TBD.