### PR TITLE
Schedule/validation PR comments from #182

### DIFF
--- a/konfera/models/schedule.py
+++ b/konfera/models/schedule.py
@@ -28,15 +28,15 @@ class Schedule(KonferaModel):
 
     def clean(self, *args, **kwargs):
         # Only approved talk can be scheduled
-        if self.talk.status != self.talk.APPROVED:
+        if self.talk and self.talk.status != self.talk.APPROVED:
             raise ValidationError({'talk': _('You cannot schedule unapproved talks.')})
 
-        # Event is related to location and location has room,
-        # make sure selected room in schedule belongs to Event's location
-        try:
-            Room.objects.get(location=self.event.location, id=self.room.id)
-        except ObjectDoesNotExist:
-            raise ValidationError({'room': _('The room does not belong to event location rooms.')})
+        # Event is related to location and location has room, make sure selected room belongs to Event's location
+        if self.room:
+            try:
+                Room.objects.get(location=self.event.location, id=self.room.id)
+            except ObjectDoesNotExist:
+                raise ValidationError({'room': _('The room does not belong to event location rooms.')})
 
         # Make sure date and time is within the event's range
 

--- a/konfera/models/schedule.py
+++ b/konfera/models/schedule.py
@@ -31,14 +31,16 @@ class Schedule(KonferaModel):
         if self.talk and self.talk.status != self.talk.APPROVED:
             raise ValidationError({'talk': _('You cannot schedule unapproved talks.')})
 
+        # Make sure date and time is within the event's range
+        if self.event.date_from > self.start or self.start > self.event.date_to:
+            raise ValidationError({'start': _('Schedule start have to be within the event\'s range.')})
+
         # Event is related to location and location has room, make sure selected room belongs to Event's location
         if self.room:
             try:
                 Room.objects.get(location=self.event.location, id=self.room.id)
             except ObjectDoesNotExist:
                 raise ValidationError({'room': _('The room does not belong to event location rooms.')})
-
-        # Make sure date and time is within the event's range
 
         # Make sure system does not allow store two events at the same
         # time in the same room, eg. schedule datetime + duration in room is unique.

--- a/konfera/tests/test_models.py
+++ b/konfera/tests/test_models.py
@@ -197,6 +197,14 @@ class ScheduleTest(TestCase):
         entry.duration = 300
         self.assertTrue(entry.full_clean)
 
+    def test_talk_status(self):
+        speaker = models.Speaker(first_name="Test", last_name="Scheduler")
+        talk = models.Talk(title="Test Talk schedule", primary_speaker=speaker, status=Talk.DRAFT)
+        entry = models.Schedule(start=timezone.now(), duration=0, talk=talk)
+        self.assertRaises(ValidationError, entry.full_clean)
+        talk.status = Talk.APPROVED
+        self.assertTrue(entry.full_clean)
+
 
 class SpeakerTest(TestCase):
 

--- a/konfera/tests/test_models.py
+++ b/konfera/tests/test_models.py
@@ -188,7 +188,14 @@ class ScheduleTest(TestCase):
         self.assertEqual(str(entry), '%s (%s min)' % (entry.start, entry.duration))
 
     def test_duration_range(self):
-        entry = models.Schedule(start="2015-01-01 01:01:01", duration=0)
+        date_from = timezone.now()
+        date_to = date_from + datetime.timedelta(days=3)
+        location = models.Location(title='test schedule location', street='test_street', city='test_city',
+                                   postcode='000000', state='test_state', capacity=20)
+        event = models.Event(title='test_event', description='test', event_type=Event.CONFERENCE,
+                             status=Event.PUBLISHED, location=location, date_from=date_from, date_to=date_to)
+
+        entry = models.Schedule(start=timezone.now(), duration=10, event=event)
         self.assertTrue(entry.full_clean)
         entry.duration = -1
         self.assertRaises(ValidationError, entry.full_clean)
@@ -196,6 +203,23 @@ class ScheduleTest(TestCase):
         self.assertRaises(ValidationError, entry.full_clean)
         entry.duration = 300
         self.assertTrue(entry.full_clean)
+
+    def test_event_daterange(self):
+        date_from = timezone.now()
+        date_to = date_from + datetime.timedelta(days=3)
+        location = models.Location(title='test schedule location', street='test_street', city='test_city',
+                                   postcode='000000', state='test_state', capacity=20)
+        event = models.Event(title='test_event', description='test', event_type=Event.CONFERENCE,
+                             status=Event.PUBLISHED, location=location, date_from=date_from, date_to=date_to)
+
+        entry = models.Schedule(start=timezone.now(), duration=10, event=event)
+        self.assertTrue(entry.full_clean)
+
+        entry = models.Schedule(start=date_from - datetime.timedelta(days=1), duration=10, event=event)
+        self.assertRaises(ValidationError, entry.full_clean)
+
+        entry = models.Schedule(start=date_from + datetime.timedelta(days=10), duration=10, event=event)
+        self.assertRaises(ValidationError, entry.full_clean)
 
     def test_talk_status(self):
         speaker = models.Speaker(first_name="Test", last_name="Scheduler")


### PR DESCRIPTION
Updated work made in PR #182 so we can close it (I didnt implement missing bit, just fixed comments so it can go t o current release).

How ever I have a thought and it is not very practical to set schedule like this. We should probably generate it. I will create a new issue for the auto generation, we have to thought about it a bit, since we need:
* easily define talks order
* easily re-schedule
* easily cancel talk

I dont think current setup allows any of this (validation, event if I would complete  missing parts, is progress but to do this in admin is pain).