### PR TITLE
#275 cfp_end can be null if cfp is not allowed

### DIFF
--- a/konfera/event/views.py
+++ b/konfera/event/views.py
@@ -344,9 +344,9 @@ class EventOrderDetailPDFView(EventOrderDetailView):
             response = PDFTemplateResponse(request=self.request, template=self.template_name,
                                            filename="order-%s.pdf" % self.object.variable_symbol,
                                            context=self.get_context_data(), show_content_in_browser=False,
-                                           cmd_options={'margin-top': 10, 'zoom': 1, 'viewport-size': '1366 x 513',
+                                           cmd_options={'margin-top': 10, 'zoom': 1.33, 'viewport-size': '1366 x 513',
                                                         'javascript-delay': 1000, 'footer-center': '[page]/[topage]',
-                                                        'no-stop-slow-scripts': True, 'dpi': 130, 'zoom': 1.33})
+                                                        'no-stop-slow-scripts': True, 'dpi': 130})
         except CalledProcessError as e:
             logger.critical('Generating PDF Order detail raised an exception: %s', e)
             messages.error(self.request, _('Generating PDF Order detail failed. Please try again later.'))

--- a/konfera/models/event.py
+++ b/konfera/models/event.py
@@ -46,7 +46,7 @@ class Event(FromToModel):
     analytics = models.TextField(blank=True)
 
     cfp_allowed = models.BooleanField(default=True, help_text=_('Is it allowed to submit talk proposals?'))
-    cfp_end = models.DateTimeField(verbose_name=_('Call for proposals deadline'), null=True)
+    cfp_end = models.DateTimeField(verbose_name=_('Call for proposals deadline'), null=True, blank=True)
     contact_email = models.EmailField(verbose_name=_('E-mail'), blank=True,
                                       help_text=_('Publicly displayed email to contact organizers.'))
     coc = models.TextField(verbose_name=_('Code of Conduct'), blank=True)


### PR DESCRIPTION
added null=True, `clean()` method already handles it correctly 